### PR TITLE
feat: BasicAttack component and TeamComponent

### DIFF
--- a/Assets/Scripts/BasicAttack.cs
+++ b/Assets/Scripts/BasicAttack.cs
@@ -1,0 +1,100 @@
+using System;
+using FishNet.Object;
+using UnityEngine;
+
+public class BasicAttack : NetworkBehaviour
+{
+    private CharacterStats _stats;
+    private TeamComponent _team;
+
+    private float _lastAttackTime;
+
+    public event Action<GameObject> OnPreAttack;
+    public event Action<GameObject> OnPostAttack;
+
+    private void Awake()
+    {
+        _stats = GetComponent<CharacterStats>();
+        _team = GetComponent<TeamComponent>();
+
+        if (_stats == null)
+            Debug.LogError($"[BasicAttack] No CharacterStats found on {gameObject.name}!");
+        if (_team == null)
+            Debug.LogError($"[BasicAttack] No TeamComponent found on {gameObject.name}!");
+    }
+
+    public bool CanAttack(GameObject target)
+    {
+        if (target == null) return false;
+
+        float attackCooldown = 1f / _stats.attackSpeed.Value;
+        if (Time.time - _lastAttackTime < attackCooldown) return false;
+
+        float distance = Vector3.Distance(transform.position, target.transform.position);
+        if (distance > _stats.attackRange.Value) return false;
+
+        TeamComponent targetTeam = target.GetComponent<TeamComponent>();
+        if (!_team.IsEnemy(targetTeam)) return false;
+
+        return true;
+    }
+
+    public void Attack(GameObject target)
+    {
+        if (!CanAttack(target)) return;
+
+        _lastAttackTime = Time.time;
+
+        Vector3 direction = (target.transform.position - transform.position).normalized;
+        direction.y = 0;
+        if (direction != Vector3.zero)
+            transform.rotation = Quaternion.LookRotation(direction);
+
+        OnPreAttack?.Invoke(target);
+
+        NetworkObject targetNetObj = target.GetComponent<NetworkObject>();
+        if (targetNetObj == null)
+        {
+            Debug.LogWarning($"[BasicAttack] Target {target.name} has no NetworkObject!");
+            return;
+        }
+
+        ServerAttack(targetNetObj);
+    }
+
+    [ServerRpc]
+    private void ServerAttack(NetworkObject targetNetObj)
+    {
+        if (targetNetObj == null) return;
+
+        HealthComponent health = targetNetObj.GetComponent<HealthComponent>();
+        if (health == null)
+        {
+            Debug.LogWarning($"[BasicAttack] Target {targetNetObj.name} has no HealthComponent!");
+            return;
+        }
+
+        DamageType damageType = _stats.data.basicAttackDamageType;
+        float damage = damageType == DamageType.Magical
+            ? _stats.abilityPower.Value
+            : _stats.attackDamage.Value;
+
+        health.TakeDamage(damage, damageType, _stats);
+
+        RpcOnPostAttack(targetNetObj.gameObject);
+
+    }
+
+    [ObserversRpc]
+    private void RpcOnPostAttack(GameObject target)
+    {
+        OnPostAttack?.Invoke(target);
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        if (_stats == null) return;
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, _stats.attackRange.Value);
+    }
+}

--- a/Assets/Scripts/BasicAttack.cs.meta
+++ b/Assets/Scripts/BasicAttack.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 373e33f12e8a88fccb2b256ad1d69591

--- a/Assets/Scripts/TeamComponent.cs
+++ b/Assets/Scripts/TeamComponent.cs
@@ -1,22 +1,24 @@
+using FishNet.Object;
+using FishNet.Object.Synchronizing;
 using UnityEngine;
 
-public class TeamComponent : MonoBehaviour
+public class TeamComponent : NetworkBehaviour
 {
     public const sbyte Neutral = -1;
 
-    public sbyte teamId;
+    public readonly SyncVar<sbyte> teamId = new SyncVar<sbyte>();
 
     public bool IsEnemy(TeamComponent other)
     {
         if (other == null) return false;
-        if (teamId == Neutral || other.teamId == Neutral) return true;
-        return teamId != other.teamId;
+        if (teamId.Value == Neutral || other.teamId.Value == Neutral) return true;
+        return teamId.Value != other.teamId.Value;
     }
 
     public bool IsAlly(TeamComponent other)
     {
         if (other == null) return false;
-        if (teamId == Neutral || other.teamId == Neutral) return false;
-        return teamId == other.teamId;
+        if (teamId.Value == Neutral || other.teamId.Value == Neutral) return false;
+        return teamId.Value == other.teamId.Value;
     }
 }

--- a/Assets/Scripts/TeamComponent.cs
+++ b/Assets/Scripts/TeamComponent.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class TeamComponent : MonoBehaviour
+{
+    public const sbyte Neutral = -1;
+
+    public sbyte teamId;
+
+    public bool IsEnemy(TeamComponent other)
+    {
+        if (other == null) return false;
+        if (teamId == Neutral || other.teamId == Neutral) return true;
+        return teamId != other.teamId;
+    }
+
+    public bool IsAlly(TeamComponent other)
+    {
+        if (other == null) return false;
+        if (teamId == Neutral || other.teamId == Neutral) return false;
+        return teamId == other.teamId;
+    }
+}

--- a/Assets/Scripts/TeamComponent.cs.meta
+++ b/Assets/Scripts/TeamComponent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 345163a85768c1fc9a101180fedfc6a8

--- a/Assets/Scripts/UnitData.cs
+++ b/Assets/Scripts/UnitData.cs
@@ -22,6 +22,7 @@ public class UnitData : ScriptableObject
     public float baseArmorPenPercent;
     public float baseFlatMagicPen;
     public float baseMagicPenPercent;
+    public DamageType basicAttackDamageType = DamageType.Physical;
 
     [Header("Defense")]
     public float baseArmor;


### PR DESCRIPTION
- Add BasicAttack component with attack cooldown, range, team validation
- Add TeamComponent with SyncVar<sbyte> teamId and IsEnemy/IsAlly checks
- Add DamageType enum (Physical, Magical, True)
- basicAttackDamageType added to UnitData (defaults to Physical)
- OnPreAttack and OnPostAttack events for passives/effects
- CanAttack public for AI and PlayerController