### PR TITLE
feat(abilities): ability framework + mana validation + cooldown HUD

### DIFF
--- a/Assets/Player-rework 1.prefab
+++ b/Assets/Player-rework 1.prefab
@@ -1076,6 +1076,7 @@ GameObject:
   - component: {fileID: 4849787816764113830}
   - component: {fileID: 6803932234606327116}
   - component: {fileID: 1548710247460741818}
+  - component: {fileID: 4528726647532828206}
   m_Layer: 6
   m_Name: Player-rework 1
   m_TagString: Untagged
@@ -1188,6 +1189,29 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 26b716c41e9b56b4baafaf13a523ba2e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  NetworkObserver: {fileID: 0}
+  _enablePrediction: 0
+  _predictionType: 0
+  _graphicalObject: {fileID: 0}
+  _detachGraphicalObject: 0
+  _enableStateForwarding: 1
+  _networkTransform: {fileID: 0}
+  _ownerInterpolation: 1
+  _ownerSmoothedProperties: 255
+  _adaptiveInterpolation: 3
+  _spectatorSmoothedProperties: 255
+  _spectatorInterpolation: 2
+  _enableTeleport: 0
+  _teleportThreshold: 1
+  <PrefabId>k__BackingField: 0
+  <SpawnableCollectionId>k__BackingField: 0
+  <AssetPathHash>k__BackingField: 2394205969364998840
+  SceneId: 0
+  SerializedTransformProperties:
+    Position: {x: 0, y: 1.49, z: 2.29}
+    Rotation: {x: 0, y: 0, z: 0, w: 1}
+    Scale: {x: 1, y: 1, z: 1}
+    IsValid: 1
   <IsNested>k__BackingField: 0
   WasActiveDuringEdit: 0
   WasActiveDuringEdit_Set1: 1
@@ -1215,29 +1239,6 @@ MonoBehaviour:
   _preventDespawnOnDisconnect: 0
   _defaultDespawnType: 0
   _initializedTimestamp: -8584252702160803057
-  NetworkObserver: {fileID: 0}
-  _enablePrediction: 0
-  _predictionType: 0
-  _graphicalObject: {fileID: 0}
-  _detachGraphicalObject: 0
-  _enableStateForwarding: 1
-  _networkTransform: {fileID: 0}
-  _ownerInterpolation: 1
-  _ownerSmoothedProperties: 255
-  _adaptiveInterpolation: 3
-  _spectatorSmoothedProperties: 255
-  _spectatorInterpolation: 2
-  _enableTeleport: 0
-  _teleportThreshold: 1
-  <PrefabId>k__BackingField: 0
-  <SpawnableCollectionId>k__BackingField: 0
-  <AssetPathHash>k__BackingField: 2394205969364998840
-  SceneId: 0
-  SerializedTransformProperties:
-    Position: {x: 0, y: 1.49, z: 2.29}
-    Rotation: {x: 0, y: 0, z: 0, w: 1}
-    Scale: {x: 1, y: 1, z: 1}
-    IsValid: 1
 --- !u!195 &88117526587501377
 NavMeshAgent:
   m_ObjectHideFlags: 0
@@ -1469,8 +1470,35 @@ MonoBehaviour:
   blankCoinPrefab: {fileID: 919132149155446097, guid: 1abb435a432b8994d9f4a07660b74c48, type: 3}
   testSceneRoot: {fileID: 0}
   duration: 3
-  initialSpinSpeed: 5000
-  spawnPos: {x: 0, y: 0, z: 0}
+  totalFullFlips: 5
+--- !u!114 &4528726647532828206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3420293684764454004}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d47772fe082e4aa7d985171587970eb9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _componentIndexCache: 255
+  _addedNetworkObject: {fileID: 2606557240988048400}
+  _networkObjectCache: {fileID: 0}
+  abilityName: YAY
+  cooldown: 5
+  manaCost: 20
+  hotkey: 119
+  shape: 0
+  radius: 4
+  fanAngle: 90
+  damage: 60
+  damageType: 1
+  targetMask:
+    serializedVersion: 2
+    m_Bits: 64
+  vfxPrefab: {fileID: 0}
 --- !u!1 &3565706969508238751
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Abilities/AbilityBase.cs
+++ b/Assets/Scripts/Abilities/AbilityBase.cs
@@ -13,13 +13,10 @@ public abstract class AbilityBase : NetworkBehaviour
     private ManaComponent _mana;
     private PlayerStateMachine _stateMachine;
 
-    // Cooldown queries
     public float Cooldown => cooldown;
     public float RemainingCooldown => Mathf.Max(0, cooldown - (Time.time - lastCastTime));
-    public float CooldownProgress => Mathf.Clamp01(1f - (RemainingCooldown / cooldown)); // 0=fresh cooldown, 1=ready
+    public float CooldownProgress => Mathf.Clamp01(1f - (RemainingCooldown / cooldown));
     public bool IsOnCooldown => RemainingCooldown > 0f;
-
-    // Info
     public KeyCode Hotkey => hotkey;
     public string AbilityName => abilityName;
     public float ManaCost => manaCost;
@@ -28,14 +25,6 @@ public abstract class AbilityBase : NetworkBehaviour
     {
         _mana = GetComponent<ManaComponent>();
         _stateMachine = GetComponent<PlayerStateMachine>();
-    }
-
-    protected virtual void Update()
-    {
-        if (!IsOwner) return;
-        if (_stateMachine != null && !_stateMachine.CanCast) return;
-        if (Input.GetKeyDown(hotkey))
-            TryCastAbility();
     }
 
     public virtual bool TryCastAbility()
@@ -54,11 +43,9 @@ public abstract class AbilityBase : NetworkBehaviour
         return true;
     }
 
-    // Base check: mana. Subclasses override this and call base.CanCast()
-    // so mana is always validated in the chain.
     protected virtual bool CanCast()
     {
-        if (_mana == null) return true; // no mana system on this unit — allow cast
+        if (_mana == null) return true;
 
         if (_mana.Current < manaCost)
         {
@@ -66,8 +53,6 @@ public abstract class AbilityBase : NetworkBehaviour
             return false;
         }
 
-        // Consume here on the owner so the cooldown doesn't start
-        // on a failed cast. Server-side consumption happens in ServerCast.
         ConsumeMana();
         return true;
     }

--- a/Assets/Scripts/Abilities/AoeAbility.cs
+++ b/Assets/Scripts/Abilities/AoeAbility.cs
@@ -47,6 +47,5 @@ public abstract class AoeAbility : AbilityBase
         return inFan.ToArray();
     }
 
-    [FishNet.Object.ServerRpc]
     protected abstract void ServerCast(Vector3 position);
 }

--- a/Assets/Scripts/Abilities/AoeCircleAbility.cs
+++ b/Assets/Scripts/Abilities/AoeCircleAbility.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+using FishNet.Object;
+
+public class AoeCircleAbility : AoeAbility
+{
+    [Header("AoE Circle")]
+    [SerializeField] private float damage = 60f;
+    [SerializeField] private DamageType damageType = DamageType.Magical;
+    [SerializeField] private LayerMask targetMask;
+    [SerializeField] private GameObject vfxPrefab; // optional — circle effect
+
+    [ServerRpc]
+    protected override void ServerCast(Vector3 position)
+    {
+        CharacterStats attackerStats = GetComponent<CharacterStats>();
+
+        Collider[] hits = GetTargetsInZone(position, targetMask);
+
+        foreach (Collider col in hits)
+        {
+            if (col.gameObject == gameObject) continue;
+
+            TeamComponent targetTeam = col.GetComponent<TeamComponent>();
+            TeamComponent myTeam = GetComponent<TeamComponent>();
+            if (targetTeam == null || myTeam == null) continue;
+            if (!myTeam.IsEnemy(targetTeam)) continue;
+
+            HealthComponent health = col.GetComponent<HealthComponent>();
+            if (health == null || health.IsDead) continue;
+
+            health.TakeDamage(damage, damageType, attackerStats);
+        }
+
+        RpcSpawnVFX(position);
+    }
+
+    [ObserversRpc]
+    private void RpcSpawnVFX(Vector3 position)
+    {
+        if (vfxPrefab == null) return;
+        GameObject vfx = Instantiate(vfxPrefab, position, Quaternion.identity);
+        Destroy(vfx, 2f);
+    }
+}

--- a/Assets/Scripts/Abilities/AoeCircleAbility.cs.meta
+++ b/Assets/Scripts/Abilities/AoeCircleAbility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d47772fe082e4aa7d985171587970eb9

--- a/Assets/Scripts/Abilities/SkillshotAbility.cs
+++ b/Assets/Scripts/Abilities/SkillshotAbility.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+public abstract class SkillshotAbility : AbilityBase
+{
+    [Header("Skillshot")]
+    [SerializeField] protected float range = 15f;
+    [SerializeField] protected float projectileSpeed = 10f;
+    [SerializeField] protected Transform shootPoint;
+
+    protected Vector3 ShootDirection { get; private set; }
+    protected Vector3 ShootOrigin { get; private set; }
+
+    protected override bool CanCast()
+    {
+        if (!base.CanCast()) return false;
+        return true;
+    }
+
+    protected override void CastAbility()
+    {
+        Camera cam = Camera.main;
+        if (cam == null) return;
+
+        Ray ray = cam.ScreenPointToRay(Input.mousePosition);
+        Vector3 targetPoint = Physics.Raycast(ray, out RaycastHit hit, 200f)
+            ? hit.point
+            : ray.GetPoint(range);
+
+        Vector3 origin = shootPoint != null ? shootPoint.position : transform.position;
+        targetPoint.y = origin.y;
+
+        ShootOrigin = origin;
+        ShootDirection = (targetPoint - origin).normalized;
+
+        Vector3 lookTarget = targetPoint;
+        lookTarget.y = transform.position.y;
+        transform.LookAt(lookTarget);
+
+        ServerCast(ShootOrigin, ShootDirection);
+    }
+
+    protected abstract void ServerCast(Vector3 origin, Vector3 direction);
+}

--- a/Assets/Scripts/Abilities/TargetedAbility.cs
+++ b/Assets/Scripts/Abilities/TargetedAbility.cs
@@ -40,6 +40,5 @@ public abstract class TargetedAbility : AbilityBase
         return hit.collider.gameObject;
     }
 
-    [FishNet.Object.ServerRpc]
     protected abstract void ServerCast(GameObject target);
 }

--- a/Assets/Scripts/Effects/StatModifierEffect.cs.meta
+++ b/Assets/Scripts/Effects/StatModifierEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4be87bee13b8c521e824a9d9806d605f

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -16,6 +16,7 @@ public class PlayerController : NetworkBehaviour
     private BasicAttack _basicAttack;
     private PlayerStateMachine _stateMachine;
     private TeamComponent _teamComponent;
+    private AbilityBase[] _abilities;
     #endregion
 
     private void Awake()
@@ -24,6 +25,7 @@ public class PlayerController : NetworkBehaviour
         _basicAttack = GetComponent<BasicAttack>();
         _stateMachine = GetComponent<PlayerStateMachine>();
         _teamComponent = GetComponent<TeamComponent>();
+        _abilities = GetComponents<AbilityBase>();
 
         if (_navMeshAgent != null)
             _navMeshAgent.angularSpeed = 0f;
@@ -49,7 +51,6 @@ public class PlayerController : NetworkBehaviour
             else
                 _cam.enabled = true;
 
-            // Initialize ability HUD for the local player
             AbilityHUD hud = FindFirstObjectByType<AbilityHUD>();
             hud?.Initialize(gameObject);
         }
@@ -132,18 +133,15 @@ public class PlayerController : NetworkBehaviour
 
             if (!_basicAttack.IsOffCooldown())
             {
-                // On cooldown — just move to cursor, ignore the target entirely
                 if (_stateMachine.CanMove)
                     ServerSetDestination(hit.point);
             }
             else if (_basicAttack.IsInRange(nearestEnemy))
             {
-                // In range and off cooldown — attack immediately
                 ServerRequestAttack(targetNob);
             }
             else
             {
-                // Off cooldown but out of range — chase until in range
                 ServerChaseForAttack(targetNob);
             }
         }
@@ -156,16 +154,20 @@ public class PlayerController : NetworkBehaviour
 
     private void HandleAbilities()
     {
-        if (!_stateMachine.CanCast) return;
-
         // Temp test keys — remove when game manager exists
         if (Input.GetKeyDown(KeyCode.T)) ServerSetTeam(0);
         if (Input.GetKeyDown(KeyCode.Y)) ServerSetTeam(1);
 
-        if (Input.GetKeyDown(KeyCode.Q)) { /* cast Q */ }
-        if (Input.GetKeyDown(KeyCode.W)) { /* cast W */ }
-        if (Input.GetKeyDown(KeyCode.E)) { /* cast E */ }
-        if (Input.GetKeyDown(KeyCode.R)) { /* cast R */ }
+        if (!_stateMachine.CanCast) return;
+
+        foreach (AbilityBase ability in _abilities)
+        {
+            if (Input.GetKeyDown(ability.Hotkey))
+            {
+                ability.TryCastAbility();
+                break; // one ability per frame
+            }
+        }
     }
 
     [ServerRpc]


### PR DESCRIPTION
## Summary
Full ability system — framework base classes, mana integration,
cooldown HUD, PlayerController wiring, and two test abilities.

## Changes

### AbilityBase.cs (refactor)
- Added ManaComponent reference, fetched in Awake()
- CanCast() validates mana, logs failure reason
- Mana consumed via ServerRpc (authoritative)
- Added CooldownProgress (0–1) for HUD radial fill
- Added ManaCost public getter
- Removed Update() — input now handled by PlayerController

### New: SkillshotAbility.cs
- Abstract base for directional projectile abilities
- Raycasts mouse → world, calculates shoot direction
- Rotates caster toward target before firing
- Subclasses implement ServerCast(Vector3 origin, Vector3 direction)

### New: TargetedAbility.cs
- Abstract base for point-and-click abilities
- Raycasts mouse → unit via LayerMask
- Validates cast range from caster
- Subclasses implement ServerCast(GameObject target)

### New: AoeAbility.cs
- Abstract base for ground-targeted area abilities
- Supports Circle and Fan shapes
- GetTargetsInZone() helper handles both shapes server-side
- Subclasses implement ServerCast(Vector3 position)

### New: FireballAbility.cs (restored)
- Extends SkillshotAbility
- Removed duplicated raycast logic
- Fixed HealthSystem → HealthComponent reference

### New: AoeCircleAbility.cs
- Extends AoeAbility, hotkey W
- Circle AoE on cursor, magical damage to enemies in zone
- RpcSpawnVFX for visual feedback

### New: AbilitySlot.cs
- Per-ability UI: icon, radial cooldown overlay, hotkey label, countdown text
- Driven by CooldownProgress and RemainingCooldown

### New: AbilityHUD.cs
- Scans local player for AbilityBase components on init
- Spawns one AbilitySlot per ability

### PlayerController.cs
- Awake(): caches AbilityBase[] via GetComponents
- OnStartClient(): initializes AbilityHUD for owner
- HandleAbilities(): iterates abilities, calls TryCastAbility() on hotkey match

## Testing
- [x] Fireball (Q) fires, damage dealt, cooldown overlay animates
- [x] AoE (W) hits enemies in radius
- [x] Mana deducted on cast
- [x] Cooldown blocks re-cast correctly
- [ ] HUD slots visible in scene (needs prefab setup)
- [ ] Casting while stunned blocked