### PR TITLE
Minion ai

### DIFF
--- a/Assets/Scripts/CharacterStats.cs
+++ b/Assets/Scripts/CharacterStats.cs
@@ -31,6 +31,9 @@ public class CharacterStats : MonoBehaviour
     public Stat moveSpeed = new();
     public Stat visionRange = new();
 
+    [Header("Misc")]
+    public int goldReward;
+
     private void Awake()
     {
         if (data == null)
@@ -60,5 +63,6 @@ public class CharacterStats : MonoBehaviour
 
         moveSpeed.BaseValue = data.baseMoveSpeed;
         visionRange.BaseValue = data.baseVisionRange;
+        goldReward = data.baseGoldReward;
     }
 }

--- a/Assets/Scripts/GoldComponent.cs
+++ b/Assets/Scripts/GoldComponent.cs
@@ -1,0 +1,15 @@
+using FishNet.Object;
+using FishNet.Object.Synchronizing;
+using UnityEngine;
+
+public class GoldComponent : NetworkBehaviour
+{
+    public readonly SyncVar<int> Gold = new SyncVar<int>();
+
+    [Server]
+    public void Award(int amount)
+    {
+        Gold.Value += amount;
+        Debug.Log($"[GoldComponent] {gameObject.name} received {amount} gold. Total: {Gold.Value}");
+    }
+}

--- a/Assets/Scripts/GoldComponent.cs.meta
+++ b/Assets/Scripts/GoldComponent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b306e4a8c9e35d10b6de6adda545fdc

--- a/Assets/Scripts/Minions.meta
+++ b/Assets/Scripts/Minions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b81c159b6f1a2d7ea6199f5d4c9cfe0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Minions/Lane.cs
+++ b/Assets/Scripts/Minions/Lane.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+public class Lane : MonoBehaviour
+{
+    [Header("Waypoints — seřadit od základny k nepřátelské základně")]
+    public Transform[] waypoints;
+
+    public sbyte teamId;
+
+    public Transform GetWaypoint(int index)
+    {
+        if (index < 0 || index >= waypoints.Length) return null;
+        return waypoints[index];
+    }
+
+    public bool IsLastWaypoint(int index) => index >= waypoints.Length - 1;
+
+#if UNITY_EDITOR
+    private void OnDrawGizmos()
+    {
+        if (waypoints == null || waypoints.Length < 2) return;
+        Gizmos.color = teamId == 0 ? Color.blue : Color.red;
+        for (int i = 0; i < waypoints.Length - 1; i++)
+        {
+            if (waypoints[i] != null && waypoints[i + 1] != null)
+                Gizmos.DrawLine(waypoints[i].position, waypoints[i + 1].position);
+        }
+    }
+#endif
+}

--- a/Assets/Scripts/Minions/Lane.cs.meta
+++ b/Assets/Scripts/Minions/Lane.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bf4905b7dbd0ca650a94311cbbbb7eb2

--- a/Assets/Scripts/Minions/MinionChaseAttackState.cs
+++ b/Assets/Scripts/Minions/MinionChaseAttackState.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+public class MinionChaseAttackState : State<MinionStateMachine>
+{
+    public MinionChaseAttackState(MinionStateMachine machine) : base(machine) { }
+
+    public override void Enter()
+    {
+        Machine.NavMeshAgent.isStopped = false;
+    }
+
+    public override void Update()
+    {
+        if (Machine.CurrentTarget == null ||
+            Machine.CurrentTarget.GetComponent<HealthComponent>()?.IsDead == true)
+        {
+            Machine.CurrentTarget = null;
+            Machine.ChangeState(new MinionRunState(Machine));
+            return;
+        }
+
+        float dist = Vector3.Distance(Machine.transform.position, Machine.CurrentTarget.transform.position);
+
+        if (dist > Machine.aggroRange * 1.5f)
+        {
+            Machine.CurrentTarget = null;
+            Machine.ChangeState(new MinionRunState(Machine));
+            return;
+        }
+
+        if (dist <= Machine.attackRange)
+        {
+            Machine.NavMeshAgent.isStopped = true;
+
+            if (Time.time - Machine.LastAttackTime >= Machine.attackCooldown)
+            {
+                Machine.LastAttackTime = Time.time;
+                Machine.CurrentTarget.GetComponent<HealthComponent>()?.TakeDamage(Machine.attackDamage, DamageType.Physical);
+            }
+        }
+        else
+        {
+            Machine.NavMeshAgent.isStopped = false;
+            Machine.NavMeshAgent.SetDestination(Machine.CurrentTarget.transform.position);
+        }
+    }
+
+    public override void Exit()
+    {
+        Machine.NavMeshAgent.isStopped = false;
+    }
+}

--- a/Assets/Scripts/Minions/MinionChaseAttackState.cs
+++ b/Assets/Scripts/Minions/MinionChaseAttackState.cs
@@ -2,11 +2,14 @@ using UnityEngine;
 
 public class MinionChaseAttackState : State<MinionStateMachine>
 {
+    private bool _isStopped = false;
+
     public MinionChaseAttackState(MinionStateMachine machine) : base(machine) { }
 
     public override void Enter()
     {
-        Machine.NavMeshAgent.isStopped = false;
+        _isStopped = false;
+        Machine.SetMoving(true);
     }
 
     public override void Update()
@@ -28,25 +31,36 @@ public class MinionChaseAttackState : State<MinionStateMachine>
             return;
         }
 
-        if (dist <= Machine.attackRange)
+        if (dist <= Machine.Stats.attackRange.Value)
         {
-            Machine.NavMeshAgent.isStopped = true;
+            if (!_isStopped)
+            {
+                Machine.SetMoving(false);
+                _isStopped = true;
+            }
 
-            if (Time.time - Machine.LastAttackTime >= Machine.attackCooldown)
+            float cooldown = 1f / Machine.Stats.attackSpeed.Value;
+            if (Time.time - Machine.LastAttackTime >= cooldown)
             {
                 Machine.LastAttackTime = Time.time;
-                Machine.CurrentTarget.GetComponent<HealthComponent>()?.TakeDamage(Machine.attackDamage, DamageType.Physical);
+                Machine.CurrentTarget.GetComponent<HealthComponent>()?
+                    .TakeDamage(Machine.Stats.attackDamage.Value, DamageType.Physical);
             }
         }
         else
         {
-            Machine.NavMeshAgent.isStopped = false;
+            if (_isStopped)
+            {
+                Machine.SetMoving(true);
+                _isStopped = false;
+            }
             Machine.NavMeshAgent.SetDestination(Machine.CurrentTarget.transform.position);
         }
     }
 
     public override void Exit()
     {
-        Machine.NavMeshAgent.isStopped = false;
+        _isStopped = false;
+        Machine.SetMoving(true);
     }
 }

--- a/Assets/Scripts/Minions/MinionChaseAttackState.cs.meta
+++ b/Assets/Scripts/Minions/MinionChaseAttackState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1321ff5adae17b45294e8ef3ecb66e00

--- a/Assets/Scripts/Minions/MinionDeathState.cs
+++ b/Assets/Scripts/Minions/MinionDeathState.cs
@@ -5,15 +5,20 @@ public class MinionDeathState : State<MinionStateMachine>
 {
     private const float DespawnDelay = 2f;
     private float _timer;
+    private readonly GameObject _killer;
 
-    public MinionDeathState(MinionStateMachine machine) : base(machine) { }
+    public MinionDeathState(MinionStateMachine machine, GameObject killer) : base(machine)
+    {
+        _killer = killer;
+    }
 
     public override void Enter()
     {
-        Machine.NavMeshAgent.isStopped = true;
         Machine.NavMeshAgent.enabled = false;
+        Machine.NavMeshObstacle.enabled = false; // dead minion shouldn't block pathing
         _timer = 0f;
-        // TODO: gold drop event
+
+        AwardGold();
     }
 
     public override void Update()
@@ -24,4 +29,18 @@ public class MinionDeathState : State<MinionStateMachine>
     }
 
     public override void Exit() { }
+
+    private void AwardGold()
+    {
+        if (_killer == null) return;
+
+        GoldComponent gold = _killer.GetComponent<GoldComponent>();
+        if (gold == null)
+        {
+            Debug.LogWarning($"[MinionDeathState] Killer {_killer.name} has no GoldComponent.");
+            return;
+        }
+
+        gold.Award(Machine.Stats.goldReward);
+    }
 }

--- a/Assets/Scripts/Minions/MinionDeathState.cs
+++ b/Assets/Scripts/Minions/MinionDeathState.cs
@@ -1,0 +1,27 @@
+using FishNet;
+using UnityEngine;
+
+public class MinionDeathState : State<MinionStateMachine>
+{
+    private const float DespawnDelay = 2f;
+    private float _timer;
+
+    public MinionDeathState(MinionStateMachine machine) : base(machine) { }
+
+    public override void Enter()
+    {
+        Machine.NavMeshAgent.isStopped = true;
+        Machine.NavMeshAgent.enabled = false;
+        _timer = 0f;
+        // TODO: gold drop event
+    }
+
+    public override void Update()
+    {
+        _timer += Time.deltaTime;
+        if (_timer >= DespawnDelay)
+            InstanceFinder.ServerManager.Despawn(Machine.NetworkObject);
+    }
+
+    public override void Exit() { }
+}

--- a/Assets/Scripts/Minions/MinionDeathState.cs.meta
+++ b/Assets/Scripts/Minions/MinionDeathState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97f95dd5810ab71b19e0fc9cd34b44af

--- a/Assets/Scripts/Minions/MinionRunState.cs
+++ b/Assets/Scripts/Minions/MinionRunState.cs
@@ -1,0 +1,75 @@
+using UnityEngine;
+
+public class MinionRunState : State<MinionStateMachine>
+{
+    public MinionRunState(MinionStateMachine machine) : base(machine) { }
+
+    public override void Enter()
+    {
+        Machine.NavMeshAgent.isStopped = false;
+        AdvanceToWaypoint();
+    }
+
+    public override void Update()
+    {
+        GameObject target = FindNearestEnemy();
+        if (target != null)
+        {
+            Machine.CurrentTarget = target;
+            Machine.ChangeState(new MinionChaseAttackState(Machine));
+            return;
+        }
+
+        if (!Machine.NavMeshAgent.pathPending &&
+            Machine.NavMeshAgent.remainingDistance < 0.5f)
+        {
+            if (Machine.AssignedLane.IsLastWaypoint(Machine.CurrentWaypointIndex))
+                return; // TODO: útok na nexus
+
+            Machine.CurrentWaypointIndex++;
+            AdvanceToWaypoint();
+        }
+    }
+
+    public override void Exit()
+    {
+        Machine.NavMeshAgent.isStopped = true;
+    }
+
+    private void AdvanceToWaypoint()
+    {
+        Transform wp = Machine.AssignedLane.GetWaypoint(Machine.CurrentWaypointIndex);
+        if (wp != null)
+            Machine.NavMeshAgent.SetDestination(wp.position);
+    }
+
+    private GameObject FindNearestEnemy()
+    {
+        Collider[] hits = Physics.OverlapSphere(
+            Machine.transform.position,
+            Machine.aggroRange,
+            LayerMask.GetMask("Characters")
+        );
+
+        GameObject nearest = null;
+        float nearestDist = Mathf.Infinity;
+
+        foreach (Collider col in hits)
+        {
+            TeamComponent targetTeam = col.GetComponent<TeamComponent>();
+            HealthComponent targetHealth = col.GetComponent<HealthComponent>();
+
+            if (targetTeam == null || targetHealth == null || targetHealth.IsDead) continue;
+            if (!Machine.Team.IsEnemy(targetTeam)) continue;
+
+            float dist = Vector3.Distance(Machine.transform.position, col.transform.position);
+            if (dist < nearestDist)
+            {
+                nearestDist = dist;
+                nearest = col.gameObject;
+            }
+        }
+
+        return nearest;
+    }
+}

--- a/Assets/Scripts/Minions/MinionRunState.cs
+++ b/Assets/Scripts/Minions/MinionRunState.cs
@@ -6,7 +6,7 @@ public class MinionRunState : State<MinionStateMachine>
 
     public override void Enter()
     {
-        Machine.NavMeshAgent.isStopped = false;
+        Machine.SetMoving(true);
         AdvanceToWaypoint();
     }
 
@@ -24,17 +24,14 @@ public class MinionRunState : State<MinionStateMachine>
             Machine.NavMeshAgent.remainingDistance < 0.5f)
         {
             if (Machine.AssignedLane.IsLastWaypoint(Machine.CurrentWaypointIndex))
-                return; // TODO: útok na nexus
+                return; // TODO: attack nexus
 
             Machine.CurrentWaypointIndex++;
             AdvanceToWaypoint();
         }
     }
 
-    public override void Exit()
-    {
-        Machine.NavMeshAgent.isStopped = true;
-    }
+    public override void Exit() { }
 
     private void AdvanceToWaypoint()
     {
@@ -48,7 +45,7 @@ public class MinionRunState : State<MinionStateMachine>
         Collider[] hits = Physics.OverlapSphere(
             Machine.transform.position,
             Machine.aggroRange,
-            LayerMask.GetMask("Characters")
+            LayerMask.GetMask("Targetable")
         );
 
         GameObject nearest = null;

--- a/Assets/Scripts/Minions/MinionRunState.cs.meta
+++ b/Assets/Scripts/Minions/MinionRunState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77e2d530a387bb02ebd06705e4bb4945

--- a/Assets/Scripts/Minions/MinionStateMachine.cs
+++ b/Assets/Scripts/Minions/MinionStateMachine.cs
@@ -1,52 +1,68 @@
 using UnityEngine;
 using UnityEngine.AI;
 using FishNet.Object;
-using FishNet.Object.Synchronizing;
 
 [RequireComponent(typeof(NavMeshAgent))]
+[RequireComponent(typeof(NavMeshObstacle))]
 [RequireComponent(typeof(HealthComponent))]
 [RequireComponent(typeof(TeamComponent))]
+[RequireComponent(typeof(CharacterStats))]
 public class MinionStateMachine : StateMachine<MinionStateMachine>
 {
-    [Header("Stats")]
-    public float attackDamage = 25f;
-    public float attackRange = 2f;
-    public float attackCooldown = 1.25f;
+    [Header("AI")]
     public float aggroRange = 8f;
-    public int goldReward = 25;
 
-    // --- References ---
     public NavMeshAgent NavMeshAgent { get; private set; }
+    public NavMeshObstacle NavMeshObstacle { get; private set; }
     public HealthComponent Health { get; private set; }
     public TeamComponent Team { get; private set; }
+    public CharacterStats Stats { get; private set; }
 
-    // --- Lane state ---
     public Lane AssignedLane { get; private set; }
     public int CurrentWaypointIndex { get; set; }
-
-    // --- Combat state ---
     public GameObject CurrentTarget { get; set; }
     public float LastAttackTime { get; set; }
 
     private void Awake()
     {
         NavMeshAgent = GetComponent<NavMeshAgent>();
+        NavMeshObstacle = GetComponent<NavMeshObstacle>();
         Health = GetComponent<HealthComponent>();
         Team = GetComponent<TeamComponent>();
+        Stats = GetComponent<CharacterStats>();
 
         if (NavMeshAgent == null) Debug.LogError($"[MinionStateMachine] Missing NavMeshAgent on {gameObject.name}");
+        if (NavMeshObstacle == null) Debug.LogError($"[MinionStateMachine] Missing NavMeshObstacle on {gameObject.name}");
         if (Health == null) Debug.LogError($"[MinionStateMachine] Missing HealthComponent on {gameObject.name}");
         if (Team == null) Debug.LogError($"[MinionStateMachine] Missing TeamComponent on {gameObject.name}");
+        if (Stats == null) Debug.LogError($"[MinionStateMachine] Missing CharacterStats on {gameObject.name}");
     }
 
     [Server]
-    public void Initialize(Lane lane)
+    public void Initialize(Lane lane, sbyte teamId)
     {
         AssignedLane = lane;
-        Team.SetTeam(lane.teamId);
         CurrentWaypointIndex = 0;
+        Team.SetTeam(teamId);
 
-        Health.OnDeath += _ => ChangeState(new MinionDeathState(this));
+        Health.OnDeath += killer => ChangeState(new MinionDeathState(this, killer));
         ChangeState(new MinionRunState(this));
+    }
+
+    public void SetMoving(bool moving)
+    {
+        if (moving)
+        {
+            NavMeshObstacle.enabled = false;
+            NavMeshAgent.enabled = true;
+            NavMeshAgent.obstacleAvoidanceType = ObstacleAvoidanceType.LowQualityObstacleAvoidance;
+        }
+        else
+        {
+            NavMeshAgent.isStopped = true;
+            NavMeshAgent.ResetPath();
+            NavMeshAgent.enabled = false;
+            NavMeshObstacle.enabled = true;
+        }
     }
 }

--- a/Assets/Scripts/Minions/MinionStateMachine.cs
+++ b/Assets/Scripts/Minions/MinionStateMachine.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using UnityEngine.AI;
+using FishNet.Object;
+using FishNet.Object.Synchronizing;
+
+[RequireComponent(typeof(NavMeshAgent))]
+[RequireComponent(typeof(HealthComponent))]
+[RequireComponent(typeof(TeamComponent))]
+public class MinionStateMachine : StateMachine<MinionStateMachine>
+{
+    [Header("Stats")]
+    public float attackDamage = 25f;
+    public float attackRange = 2f;
+    public float attackCooldown = 1.25f;
+    public float aggroRange = 8f;
+    public int goldReward = 25;
+
+    // --- References ---
+    public NavMeshAgent NavMeshAgent { get; private set; }
+    public HealthComponent Health { get; private set; }
+    public TeamComponent Team { get; private set; }
+
+    // --- Lane state ---
+    public Lane AssignedLane { get; private set; }
+    public int CurrentWaypointIndex { get; set; }
+
+    // --- Combat state ---
+    public GameObject CurrentTarget { get; set; }
+    public float LastAttackTime { get; set; }
+
+    private void Awake()
+    {
+        NavMeshAgent = GetComponent<NavMeshAgent>();
+        Health = GetComponent<HealthComponent>();
+        Team = GetComponent<TeamComponent>();
+
+        if (NavMeshAgent == null) Debug.LogError($"[MinionStateMachine] Missing NavMeshAgent on {gameObject.name}");
+        if (Health == null) Debug.LogError($"[MinionStateMachine] Missing HealthComponent on {gameObject.name}");
+        if (Team == null) Debug.LogError($"[MinionStateMachine] Missing TeamComponent on {gameObject.name}");
+    }
+
+    [Server]
+    public void Initialize(Lane lane)
+    {
+        AssignedLane = lane;
+        Team.SetTeam(lane.teamId);
+        CurrentWaypointIndex = 0;
+
+        Health.OnDeath += _ => ChangeState(new MinionDeathState(this));
+        ChangeState(new MinionRunState(this));
+    }
+}

--- a/Assets/Scripts/Minions/MinionStateMachine.cs.meta
+++ b/Assets/Scripts/Minions/MinionStateMachine.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbabcba32c5fab519817bc2f3bb3bdde

--- a/Assets/Scripts/Minions/WaveSpawner.cs
+++ b/Assets/Scripts/Minions/WaveSpawner.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using UnityEngine;
 using FishNet.Object;
+using FishNet;
 
 public class WaveSpawner : NetworkBehaviour
 {

--- a/Assets/Scripts/Minions/WaveSpawner.cs
+++ b/Assets/Scripts/Minions/WaveSpawner.cs
@@ -8,13 +8,16 @@ public class WaveSpawner : NetworkBehaviour
     [Header("Prefabs")]
     [SerializeField] private NetworkObject minionPrefab;
 
+    [Header("Team")]
+    [SerializeField] private sbyte teamId; // 0 = Blue, 1 = Red
+
     [Header("Lanes")]
-    [SerializeField] private Lane[] lanes; // přiřaď všechny lane objekty ze scény
+    [SerializeField] private Lane[] lanes;
 
     [Header("Wave Settings")]
     [SerializeField] private int minionsPerWave = 6;
     [SerializeField] private float timeBetweenWaves = 30f;
-    [SerializeField] private float timeBetweenSpawns = 0.5f; // interval mezi spawnem jednotlivých minionů v jedné vlně
+    [SerializeField] private float timeBetweenSpawns = 0.5f;
 
     private int _waveNumber = 0;
 
@@ -26,7 +29,7 @@ public class WaveSpawner : NetworkBehaviour
 
     private IEnumerator WaveLoop()
     {
-        yield return new WaitForSeconds(5f); // krátká pauza na začátku hry
+        yield return new WaitForSeconds(5f);
 
         while (true)
         {
@@ -54,12 +57,12 @@ public class WaveSpawner : NetworkBehaviour
         Transform spawnPoint = lane.GetWaypoint(0);
         if (spawnPoint == null)
         {
-            Debug.LogError($"[WaveSpawner] Lane {lane.name} má null waypoint na indexu 0!");
+            Debug.LogError($"[WaveSpawner] Lane {lane.name} has null waypoint at index 0!");
             return;
         }
 
         NetworkObject nob = Instantiate(minionPrefab, spawnPoint.position, spawnPoint.rotation);
         InstanceFinder.ServerManager.Spawn(nob);
-        nob.GetComponent<MinionStateMachine>().Initialize(lane);
+        nob.GetComponent<MinionStateMachine>().Initialize(lane, teamId);
     }
 }

--- a/Assets/Scripts/Minions/WaveSpawner.cs
+++ b/Assets/Scripts/Minions/WaveSpawner.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using UnityEngine;
+using FishNet.Object;
+
+public class WaveSpawner : NetworkBehaviour
+{
+    [Header("Prefabs")]
+    [SerializeField] private NetworkObject minionPrefab;
+
+    [Header("Lanes")]
+    [SerializeField] private Lane[] lanes; // přiřaď všechny lane objekty ze scény
+
+    [Header("Wave Settings")]
+    [SerializeField] private int minionsPerWave = 6;
+    [SerializeField] private float timeBetweenWaves = 30f;
+    [SerializeField] private float timeBetweenSpawns = 0.5f; // interval mezi spawnem jednotlivých minionů v jedné vlně
+
+    private int _waveNumber = 0;
+
+    public override void OnStartServer()
+    {
+        base.OnStartServer();
+        StartCoroutine(WaveLoop());
+    }
+
+    private IEnumerator WaveLoop()
+    {
+        yield return new WaitForSeconds(5f); // krátká pauza na začátku hry
+
+        while (true)
+        {
+            _waveNumber++;
+            yield return StartCoroutine(SpawnWave());
+            yield return new WaitForSeconds(timeBetweenWaves);
+        }
+    }
+
+    private IEnumerator SpawnWave()
+    {
+        foreach (Lane lane in lanes)
+        {
+            for (int i = 0; i < minionsPerWave; i++)
+            {
+                SpawnMinion(lane);
+                yield return new WaitForSeconds(timeBetweenSpawns);
+            }
+        }
+    }
+
+    [Server]
+    private void SpawnMinion(Lane lane)
+    {
+        Transform spawnPoint = lane.GetWaypoint(0);
+        if (spawnPoint == null)
+        {
+            Debug.LogError($"[WaveSpawner] Lane {lane.name} má null waypoint na indexu 0!");
+            return;
+        }
+
+        NetworkObject nob = Instantiate(minionPrefab, spawnPoint.position, spawnPoint.rotation);
+        InstanceFinder.ServerManager.Spawn(nob);
+        nob.GetComponent<MinionStateMachine>().Initialize(lane);
+    }
+}

--- a/Assets/Scripts/Minions/WaveSpawner.cs.meta
+++ b/Assets/Scripts/Minions/WaveSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1e9de299a85bf35c2af7059076fee0dd

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -34,6 +34,8 @@ public class PlayerController : NetworkBehaviour
         if (_basicAttack == null) Debug.LogError("[PlayerController] No BasicAttack found!");
         if (_stateMachine == null) Debug.LogError("[PlayerController] No PlayerStateMachine found!");
         if (_teamComponent == null) Debug.LogError("[PlayerController] No TeamComponent found!");
+
+        // _navMeshAgent.obstacleAvoidanceType = ObstacleAvoidanceType.NoObstacleAvoidance;
     }
 
     public override void OnStartClient()

--- a/Assets/Scripts/UnitData.cs
+++ b/Assets/Scripts/UnitData.cs
@@ -31,4 +31,7 @@ public class UnitData : ScriptableObject
     [Header("Mobility")]
     public float baseMoveSpeed;
     public float baseVisionRange;
+
+    [Header("Misc")]
+    public int baseGoldReward;
 }


### PR DESCRIPTION
## Minion Wave System

Implements full minion loop: spawn → path → aggro → attack → death → gold.

### Changes
- `MinionStateMachine` — references, SetMoving() agent/obstacle swap
- `MinionRunState` — waypoint following, nearest enemy detection
- `MinionChaseAttackState` — chase and attack with frame-safe stop guard
- `MinionDeathState` — timed despawn, gold award to killer
- `WaveSpawner` — per-team configurable wave spawning
- `GoldComponent` — networked gold tracking
- `Lane` — path data with editor visualization

### Known issues
- Player can clip through minions when no NavMesh path exists (post-deadline polish)

### Next
Towers → Nexus win condition